### PR TITLE
fix: Set S3 version to prevent authorisation failure in eu-central-1 …

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ class S3Assets {
 
         // init hooks
         const interpreter = new ConfigIntepreter(FS, S3File, serverless.cli);
-        const s3Uploader = new S3Uploader(new AWS.S3(), FS, serverless.cli);
+        const s3Uploader = new S3Uploader(new AWS.S3({ signatureVersion: 'v4' }), FS, serverless.cli);
         const config = serverless.service.custom && serverless.service.custom.s3Assets ? serverless.service.custom.s3Assets : [];
         this.hooks = {
             'after:deploy:deploy': this.deploy.bind(this, interpreter, s3Uploader, config),


### PR DESCRIPTION
…region

Without the `new AWS.S3({ signatureVersion: 'v4' })` the push request failed in Frankfurt region (eu-central-1) as follows
```
Serverless: Failed to get files for "<some file>"
Serverless: Start uploading S3 assets
Serverless: InvalidRequest: The authorization mechanism you have provided is not supported. Please use AWS4-HMAC-SHA256.
```

Failure reason explained in this [stack exchange post](https://craftcms.stackexchange.com/questions/5437/errors-occuring-with-assets-and-amazon-s3).