### PR TITLE
Fix Content type and non directory iterations, add commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Sometimes you have some fixed assets that need to be uploaded to S3, such as ima
 
 To use this, you'll need to specify the files to copy to your bucket. You do this in serverless.yml:
 
-```
+```yaml
 plugins:
   - serverless-s3-assets
 
@@ -35,6 +35,24 @@ The `test-html` is the relative folder name of the files to upload to the bucket
 
 Any other options specified will be treated as sub-folder names, like `templates` above. This also shows you how to have sub-folders with different settings. By default, all files and folders within the specified root folder name will be uploaded with the same options as that root folder.
 
+### Commands
+
+The code will trigger automatically during a `serverless deploy` and `serverless remove`.
+
+You can also carry out S3 deployment or removal independent from stack deployments:
+
+```yaml
+sls s3delpoy
+
+sls s3remove
+```
+
+If you have defined multiple assets (folders) you can limit the action to a single one:
+
+```yaml
+sls s3delpoy --asset test-html
+```
+
 ### Gotchas
 
 Make sure you don't add any additional files to your bucket that you're specifying in s3Assets. If you do and then run `serverless remove` then those additional files will also be removed.
@@ -42,7 +60,3 @@ Make sure you don't add any additional files to your bucket that you're specifyi
 ### Permissions
 
 You don't need any special permissions for your Lambda as the code is run by Serverless instead.
-
-### Commands
-
-The code will trigger automatically during a `serverless deploy`.

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ The `test-html` is the relative folder name of the files to upload to the bucket
 - isPublic: set this to true or false to override any ACL setting. True is the same as `public-read` and false is the same as `private`.
 - cacheControl: Any cache control settings.
 - cacheTime: This overrides any existing cache-control settings and sets a max-age for the file.
-- contentType: The type of content we're uploading, if not obvious.
+- contentType: default type of content we're uploading, if not obvious. Plugin will try to derive the type from file extention first.
 - metadata: Any extra metadata to upload.
 
 Any other options specified will be treated as sub-folder names, like `templates` above. This also shows you how to have sub-folders with different settings. By default, all files and folders within the specified root folder name will be uploaded with the same options as that root folder.

--- a/index.js
+++ b/index.js
@@ -17,20 +17,49 @@ class S3Assets {
         const interpreter = new ConfigIntepreter(FS, S3File, serverless.cli);
         const s3Uploader = new S3Uploader(new AWS.S3({ signatureVersion: 'v4' }), FS, serverless.cli);
         const config = serverless.service.custom && serverless.service.custom.s3Assets ? serverless.service.custom.s3Assets : [];
+        this.options = options;
+        this.commands = {
+            s3deploy: {
+                usage: 'Deploy assets to S3 bucket',
+                lifecycleEvents: [
+                    'deploy'
+                ],
+                options: {
+                    asset: {
+                        usage: 'Limit the deployment to a specific asset',
+                        shortcut: 'a'
+                    }
+                }
+            },
+            s3remove: {
+                usage: 'Remove deployed assets from S3 bucket',
+                lifecycleEvents: [
+                    'remove'
+                ],
+                options: {
+                    asset: {
+                        usage: 'Limit the removement to a specific asset',
+                        shortcut: 'a'
+                    }
+                }
+            }
+        };
         this.hooks = {
+            's3deploy:deploy': this.deploy.bind(this, interpreter, s3Uploader, config),
+            's3remove:remove': this.remove.bind(this, interpreter, s3Uploader, config),
             'after:deploy:deploy': this.deploy.bind(this, interpreter, s3Uploader, config),
             'before:remove:remove': this.remove.bind(this, interpreter, s3Uploader, config)
         };
     }
 
     deploy(interpreter, s3Uploader, config) {
-        const files = interpreter.get(config);
+        const files = interpreter.get(config, this.options);
         return s3Uploader.uploadAllToBucket(files);
     }
 
     remove(interpreter, s3Uploader, config) {
         const buckets = [];
-        const files = interpreter.get(config);
+        const files = interpreter.get(config, this.options);
         for (let file of files) {
             buckets[buckets.length] = file.getBucket();
         }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Uploads requested assets to S3 as part of Serverless deploy",
   "main": "index.js",
   "dependencies": {
-    "aws-sdk": "^2.6.9"
+    "aws-sdk": "^2.6.9",
+    "mime-types": "^2.1.18"
   },
   "devDependencies": {
     "chai": "^3.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-s3-assets",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Uploads requested assets to S3 as part of Serverless deploy",
   "main": "index.js",
   "dependencies": {

--- a/src/ConfigInterpreter.js
+++ b/src/ConfigInterpreter.js
@@ -7,10 +7,14 @@ class ConfigInterpreter {
         this.logger = logger;
     }
 
-    get(config) {
+    get(config, options) {
         // loop through each first-level of files / folders defined
         const folders = [];
         for (let folder of Object.keys(config)) {
+            if(options && options.asset && options.asset !== folder) {
+                this.logger.log('Skipping folder: ' + folder);
+                continue;
+            }
             // gets the first level of data
             const s3Folder = new this.S3File(folder, '', '', config[folder]);
             s3Folder.addFiles(this.getFilesForFolder(folder), config[folder]);
@@ -35,7 +39,7 @@ class ConfigInterpreter {
 
     getFilesForFolder(folder) {
         try {
-            return this.FS.readdirSync(folder);
+            return this.FS.lstatSync(folder).isDirectory() ? this.FS.readdirSync(folder) : [];
         } catch (error) {
             this.logger.log('Failed to get files for "' + folder + '"');
             return [];

--- a/src/S3File.js
+++ b/src/S3File.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const mime = require('mime-types');
+
 class S3File {
     constructor(name, filePath, relativePath, settings) {
         this.files = [];
@@ -69,7 +71,7 @@ class S3File {
     }
 
     getContentType() {
-        return this.settings.contentType || 'text/plain';
+        return mime.lookup(this.getFilePath()) || this.settings.contentType || 'text/plain';
     }
 
     /**

--- a/src/S3Uploader.js
+++ b/src/S3Uploader.js
@@ -1,6 +1,4 @@
 'use strict';
-
-const mime = require('mime-types');
 class S3Uploader {
     constructor(s3, FS, logger) {
         this.s3 = s3;
@@ -39,7 +37,7 @@ class S3Uploader {
                 Body: this.FS.readFileSync(file.getFilePath()),
                 ACL: file.getAcl(),
                 CacheControl: file.getCacheControl(),
-                ContentType: mime.lookup(file.getFilePath()) || file.getContentType(),
+                ContentType: file.getContentType(),
                 Metadata: file.getMetadata()
             };
 

--- a/src/S3Uploader.js
+++ b/src/S3Uploader.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const mime = require('mime-types');
 class S3Uploader {
     constructor(s3, FS, logger) {
         this.s3 = s3;
@@ -38,7 +39,7 @@ class S3Uploader {
                 Body: this.FS.readFileSync(file.getFilePath()),
                 ACL: file.getAcl(),
                 CacheControl: file.getCacheControl(),
-                ContentType: file.getContentType(),
+                ContentType: mime.lookup(file.getFilePath()) || file.getContentType(),
                 Metadata: file.getMetadata()
             };
 

--- a/test/src/ConfigInterpreter.js
+++ b/test/src/ConfigInterpreter.js
@@ -47,9 +47,12 @@ describe('src/ConfigInterpreter', function () {
         const FS = {
             readdirSync: (folder) => {
                 return [folder, 'a', 'b'];
+            },
+            lstatSync: (folder) => {
+                return { isDirectory: () => true }
             }
         };
-        const config = new ConfigInterpreter(FS, {}, {});
+        const config = new ConfigInterpreter(FS, {}, console);
         expect(config.getFilesForFolder('folder')).to.have.same.members(['folder', 'a', 'b']);
     });
 
@@ -57,6 +60,9 @@ describe('src/ConfigInterpreter', function () {
         const FS = {
             readdirSync: (folder) => {
                 throw new Error('Test fail');
+            },
+            lstatSync: (folder) => {
+                return { isDirectory: () => true }
             }
         };
         const logger = {
@@ -88,7 +94,10 @@ describe('src/ConfigInterpreter', function () {
                     return {getName: () => 'f', getFilePath: () => folder, getFiles: () => [FS.readdirSync('a/c/f/h'), FS.readdirSync('a/c/f/i')], addFiles: (files) => {FS.storedFiles.push({folder, files})}};
                 }
                 return {getName: () => folder, getFilePath: () => folder, getFiles: () => [], addFiles: (files) => {FS.storedFiles.push({folder, files})}};
-            }
+            },
+            lstatSync: (folder) => {
+                return { isDirectory: () => true }
+            }            
         };
         const config = new ConfigInterpreter(FS, {}, {});
         config.getSubs([FS.readdirSync('a')], {});
@@ -106,6 +115,9 @@ describe('src/ConfigInterpreter', function () {
                     return ['a/c/e', 'a/c/f', 'a/c/g'];
                 }
                 return [];
+            },
+            lstatSync: (folder) => {
+                return { isDirectory: () => true }
             }
         };
         const config = new ConfigInterpreter(FS, FullS3FileTest, {});


### PR DESCRIPTION
1) For websites it is important to load different and correct ;) content-type for each resource (html, js, css, ect) and not always the same from settings. Fixed
2) An error was for every file thrown, as the algorithm was trying to iterate it without check if it is derectory or file. Fixed
3) Commands added to be able trigger S3 deployment and removal independent from serverless basic functions